### PR TITLE
Call bower via npm

### DIFF
--- a/steps/step_03/02_build_openrov-cockpit.sh
+++ b/steps/step_03/02_build_openrov-cockpit.sh
@@ -68,9 +68,8 @@ npm install --arch=armhf || onerror
 git clean -d -x -f -e node_modules
 
 cd src/static
-npm install -g bower
-bower --allow-root --config.interactive=false install
-
+npm install
+npm run bower
 
 cat > $ROOT/tmp/build_cockpit.sh << __EOF__
 #!/bin/sh


### PR DESCRIPTION
In companion with https://github.com/OpenROV/openrov-software/pull/271

Installing bower globally on the build server could bring issues if another project uses another bower version at one point.
and rather then running bower directly, the package.json now has the right parameters for bower.
