### PR TITLE
Moved to installing packages as a single suite

### DIFF
--- a/steps/04_customize_image.sh
+++ b/steps/04_customize_image.sh
@@ -116,7 +116,7 @@ rm -rf /tmp/packages
 if [ "$USE_REPO" != "" ]; then
 	apt-get update
 	apt-get install -y --force-yes -o Dpkg::Options::="--force-overwrite" \
-		-t $BRANCH openrov-onrov-suite
+		-t $BRANCH openrov-rov-suite
 fi
 apt-get clean
 


### PR DESCRIPTION
Refer to #68 
This PR is intended to make all of the changes needed to the build scripts to install a single meta package that has all of the other packages as dependencies.  This is to facilitate an upgrade process where only the meta package is explicitly upgraded. 
